### PR TITLE
Allow `-idist...` in the argument list.

### DIFF
--- a/src/Snap/Loader/Dynamic.hs
+++ b/src/Snap/Loader/Dynamic.hs
@@ -92,9 +92,7 @@ getHintOpts args = removeBad opts
     hideAll   = filter (== "-hide-all-packages") args
 
     --------------------------------------------------------------------------
-    srcOpts   = filter (\x -> "-i" `isPrefixOf` x
-                              && not ("-idist" `isPrefixOf` x))
-                       args
+    srcOpts   = filter (\x -> "-i" `isPrefixOf` x) args
 
     --------------------------------------------------------------------------
     toCopy    = filter (not . isSuffixOf ".hs") $


### PR DESCRIPTION
Allow `-idist...` in the argument list so that `Paths_pkgname` is available.
