### PR TITLE
Explicitly add `Snap.Snaplet.Config` as an imported module for the `hint` interpreter

### DIFF
--- a/src/Snap/Loader/Dynamic.hs
+++ b/src/Snap/Loader/Dynamic.hs
@@ -161,7 +161,11 @@ hintSnap opts modules srcPaths action value =
     --------------------------------------------------------------------------
     interpreter = do
         loadModules . nub $ modules
-        setImports . nub $ "Prelude" : "Snap.Core" : witnessModules ++ modules
+        setImports . nub $ "Prelude"
+                         : "Snap.Core"
+                         : "Snap.Snaplet.Config"
+                         : witnessModules
+                        ++ modules
 
         f <- interpret action witness
         return $ f value


### PR DESCRIPTION
This addresses snapframework/snap-core#170.

Adding `Snap.Snaplet.Config` to the `setImports` module list seems to avoid the error I reported in the ticket mentioned above.

There may be a better way to fix this problem; this is just the way I managed to do it. Comments or alternative suggestions are welcome!
