### PR TITLE
Fixing for snap 1.0 (where Snap.Types is removed)

### DIFF
--- a/snap-loader-dynamic.cabal
+++ b/snap-loader-dynamic.cabal
@@ -32,7 +32,7 @@ Library
     base              >= 4       && < 5,
     directory-tree    >= 0.10    && < 0.12,
     mtl               >  2.0     && < 2.2,
-    snap-core         >= 0.9     && < 0.10,
+    snap-core         >= 1.0     && < 1.1,
     time              >= 1.1     && < 1.5,
     template-haskell  >= 2.2     && < 2.10
 

--- a/src/Snap/Loader/Dynamic.hs
+++ b/src/Snap/Loader/Dynamic.hs
@@ -161,8 +161,9 @@ hintSnap opts modules srcPaths action value = do
 
     --------------------------------------------------------------------------
     dropInternal s = case stripPrefix "Snap.Internal." s of
-        Nothing -> s
-        Just x  -> "Snap." ++ x
+        Nothing      -> s
+        Just "Types" -> "Snap.Core"
+        Just x       -> "Snap." ++ x
 #else
     --------------------------------------------------------------------------
     -- This is somewhat fragile, and probably can be cleaned up with a future


### PR DESCRIPTION
Not sure if this is the right fix, but it was broken and this seems to work.
