### PR TITLE
Filter additional hint options (-XHaskell -ddump-hi)

### DIFF
--- a/snap-loader-dynamic.cabal
+++ b/snap-loader-dynamic.cabal
@@ -34,11 +34,11 @@ Library
     mtl               >  2.0     && < 2.3,
     snap-core         >= 1.0     && < 1.1,
     time              >= 1.1     && < 1.9,
-    template-haskell  >= 2.2     && < 2.13
+    template-haskell  >= 2.2     && < 2.14
 
   if impl(ghc >= 7.2.0)
     build-depends:
-      hint              >= 0.3.3.1 && < 0.8
+      hint              >= 0.3.3.1 && < 0.9
   else
     build-depends:
       hint              >= 0.3.3.1 && < 0.3.3.5

--- a/snap-loader-dynamic.cabal
+++ b/snap-loader-dynamic.cabal
@@ -38,7 +38,7 @@ Library
 
   if impl(ghc >= 7.2.0)
     build-depends:
-      hint              >= 0.3.3.1 && < 0.9
+      hint              >= 0.3.3.1 && < 1.0
   else
     build-depends:
       hint              >= 0.3.3.1 && < 0.3.3.5

--- a/src/Snap/Loader/Dynamic.hs
+++ b/src/Snap/Loader/Dynamic.hs
@@ -86,7 +86,7 @@ getHintOpts :: [String] -> [String]
 getHintOpts args = removeBad opts
   where
     --------------------------------------------------------------------------
-    bad       = ["-threaded", "-O", "-main-is", "-o", "--make", "-static"]
+    bad       = ["-threaded", "-O", "-main-is", "-o", "--make", "-static", "-XHaskell"]
 
     --------------------------------------------------------------------------
     removeBad = filter (\x -> not $ any (`isPrefixOf` x) bad)

--- a/src/Snap/Loader/Dynamic.hs
+++ b/src/Snap/Loader/Dynamic.hs
@@ -86,7 +86,7 @@ getHintOpts :: [String] -> [String]
 getHintOpts args = removeBad opts
   where
     --------------------------------------------------------------------------
-    bad       = ["-threaded", "-O", "-main-is", "-o", "--make", "-static", "-XHaskell"]
+    bad       = ["-threaded", "-O", "-main-is", "-o", "--make", "-static", "-XHaskell", "-ddump-hi"]
 
     --------------------------------------------------------------------------
     removeBad = filter (\x -> not $ any (`isPrefixOf` x) bad)


### PR DESCRIPTION
Having `default-language:    Haskell2010` in the `.cabal` file can lead to hint throwing "Unknown interpreter error". Filtering out this option fixes the issue.

Similarly, as discussed in this [`hint` issue](https://github.com/haskell-hint/hint/issues/78), the option `-ddump-hi` that `snap-loader-dynamic` passes to `hint` can lead to the latter being unable to empty a temporary directory, which causes it to fail completely. Filtering out `-ddump-hi` fixes the problem (found by @nwg and @gelisam).